### PR TITLE
[test] NeTEx IDFM - Add fixtures for VehicleJourneyStopAssignement

### DIFF
--- a/tests/fixtures/netexidf2ntfs/input/netex/OFFRE_TP/offre_tp.xml
+++ b/tests/fixtures/netexidf2ntfs/input/netex/OFFRE_TP/offre_tp.xml
@@ -66,6 +66,26 @@
                         </StopPointInJourneyPattern>
                      </pointsInSequence>
                   </ServiceJourneyPattern>
+                  <ServiceJourneyPattern dataSourceRef="DATASOURCEREF_EDITION_BOIV" id="stif:JourneyPattern:local-26-C00114-3:LOC" version="any">
+                     <RouteRef ref="stif:Route:local-26-C00114-2:LOC" version="any"/>
+                     <pointsInSequence>
+                        <StopPointInJourneyPattern id="stif:JourneyPattern:local-26-C00114-24:LOC" order="1" version="any">
+                           <ScheduledStopPointRef ref="stif:ScheduledStopPoint:local-26-C00114-23:LOC" version="any"/>
+                           <ForAlighting>true</ForAlighting>
+                           <ForBoarding>true</ForBoarding>
+                        </StopPointInJourneyPattern>
+                        <StopPointInJourneyPattern id="stif:JourneyPattern:local-26-C00114-25:LOC" order="2" version="any">
+                           <ScheduledStopPointRef ref="stif:ScheduledStopPoint:local-26-C00114-24:LOC" version="any"/>
+                           <ForAlighting>true</ForAlighting>
+                           <ForBoarding>true</ForBoarding>
+                        </StopPointInJourneyPattern>
+                        <StopPointInJourneyPattern id="stif:JourneyPattern:local-26-C00114-26:LOC" order="3" version="any">
+                           <ScheduledStopPointRef ref="stif:ScheduledStopPoint:local-26-C00114-25:LOC" version="any"/>
+                           <ForAlighting>true</ForAlighting>
+                           <ForBoarding>true</ForBoarding>
+                        </StopPointInJourneyPattern>
+                     </pointsInSequence>
+                  </ServiceJourneyPattern>
                   <PassengerStopAssignment dataSourceRef="DATASOURCEREF_EDITION_BOIV" id="stif:PassengerStopAssignment:local-26-C00114-10:LOC" version="any" order="0">
                      <ScheduledStopPointRef ref="stif:ScheduledStopPoint:local-26-C00114-10:LOC" version="any" />
                      <QuayRef ref="FR::Quay:50144192:FR1">version="any"</QuayRef>
@@ -93,6 +113,18 @@
                   <PassengerStopAssignment dataSourceRef="DATASOURCEREF_EDITION_BOIV" id="stif:PassengerStopAssignment:local-26-C00114-22:LOC" version="any" order="0">
                      <ScheduledStopPointRef ref="stif:ScheduledStopPoint:local-26-C00114-22:LOC" version="any" />
                      <QuayRef ref="FR::Quay:50144192:FR1">version="any"</QuayRef>
+                  </PassengerStopAssignment>
+                   <PassengerStopAssignment dataSourceRef="DATASOURCEREF_EDITION_BOIV" id="stif:PassengerStopAssignment:local-26-C00114-23:LOC" version="any" order="0">
+                     <ScheduledStopPointRef ref="stif:ScheduledStopPoint:local-26-C00114-23:LOC" version="any" />
+                     <StopPlaceRef ref="FR::monomodalStopPlace:57250:FR1" version="any" />
+                  </PassengerStopAssignment>
+                   <PassengerStopAssignment dataSourceRef="DATASOURCEREF_EDITION_BOIV" id="stif:PassengerStopAssignment:local-26-C00114-24:LOC" version="any" order="0">
+                     <ScheduledStopPointRef ref="stif:ScheduledStopPoint:local-26-C00114-24:LOC" version="any" />
+                     <StopPlaceRef ref="FR::monomodalStopPlace:sp_with_parent_not_found:FR1" version="any" />
+                  </PassengerStopAssignment>
+                   <PassengerStopAssignment dataSourceRef="DATASOURCEREF_EDITION_BOIV" id="stif:PassengerStopAssignment:local-26-C00114-25:LOC" version="any" order="0">
+                     <ScheduledStopPointRef ref="stif:ScheduledStopPoint:local-26-C00114-25:LOC" version="any" />
+                     <QuayRef ref="FR::Quay:50114580:FR1" version="any" />
                   </PassengerStopAssignment>
                   <RoutingConstraintZone dataSourceRef="DATASOURCEREF_EDITION_BOIV" id="stif:RoutingConstraintZone:local-26-C00114:LOC" version="any">
                      <Name>ITL 1</Name>
@@ -190,9 +222,42 @@
                         </TimetabledPassingTime>
                      </passingTimes>
                   </ServiceJourney>
+                  <ServiceJourney dataSourceRef="DATASOURCEREF_EDITION_BOIV" id="stif:VehicleJourney:local-26-C00114-3:LOC" version="any">
+                     <dayTypes>
+                        <DayTypeRef ref="stif:TimeTable:local-28-2:LOC">version="1"</DayTypeRef>
+                     </dayTypes>
+                     <JourneyPatternRef ref="stif:JourneyPattern:local-26-C00114-3:LOC" version="any"/>
+                     <passingTimes>
+                        <TimetabledPassingTime version="any">
+                           <ArrivalTime>06:30:00</ArrivalTime>
+                           <DepartureTime>06:30:00</DepartureTime>
+                           <DepartureDayOffset>0</DepartureDayOffset>
+                        </TimetabledPassingTime>
+                        <TimetabledPassingTime version="any">
+                           <ArrivalTime>07:05:00</ArrivalTime>
+                           <DepartureTime>07:05:00</DepartureTime>
+                           <DepartureDayOffset>0</DepartureDayOffset>
+                        </TimetabledPassingTime>
+                        <TimetabledPassingTime version="any">
+                           <ArrivalTime>07:15:00</ArrivalTime>
+                           <DepartureTime>07:15:00</DepartureTime>
+                           <DepartureDayOffset>0</DepartureDayOffset>
+                        </TimetabledPassingTime>
+                     </passingTimes>
+                  </ServiceJourney>
+                  <VehicleJourneyStopAssignment dataSourceRef="STIF" id="stif:VehicleJourneyStopAssignment:local-26-C00114-1:LOC" version="any">
+                     <QuayRef ref="FR::Quay:50144192:FR1">version="any"</QuayRef>
+                     <ScheduledStopPointRef ref="stif:ScheduledStopPoint:local-26-C00114-23:LOC" version="any"/>
+                     <VehicleJourneyRef ref="stif:VehicleJourney:local-26-C00114-3:LOC" version="any"/>
+                  </VehicleJourneyStopAssignment>
+                  <VehicleJourneyStopAssignment dataSourceRef="STIF" id="stif:VehicleJourneyStopAssignment:local-26-C00114-1:LOC" version="any">
+                     <QuayRef ref="FR::Quay:50068421:FR1">version="any"</QuayRef>
+                     <ScheduledStopPointRef ref="stif:ScheduledStopPoint:local-26-C00114-24:LOC" version="any"/>
+                     <VehicleJourneyRef ref="stif:VehicleJourney:local-26-C00114-3:LOC" version="any"/>
+                  </VehicleJourneyStopAssignment>
                </members>
             </GeneralFrame>
-		</frames>
+         </frames>
       </CompositeFrame>
    </dataObjects>
 </PublicationDelivery>


### PR DESCRIPTION
I added one new `ServiceJourneyPattern` with 3 stops. The 2 first `ScheduledStopPoint` are using a `PassengerStopAssignment` with a `StopPlaceRef`, the third one is a `ScheduledStopPoint` with a `QuayRef`.

For this `ServiceJourneyPattern`, I created 1 `ServiceJourney` and then 2 `VehicleJourneyStopAssignment`.